### PR TITLE
Use more efficient emptiness check

### DIFF
--- a/src/msgpack.cc
+++ b/src/msgpack.cc
@@ -252,7 +252,7 @@ pack(const Arguments &args) {
     MsgpackZone mz;
     msgpack_sbuffer *sb;
 
-    if (sbuffers.size()) {
+    if (!sbuffers.empty()) {
         sb = sbuffers.top();
         sbuffers.pop();
     } else {


### PR DESCRIPTION
Using empty() instead of size() can be faster. size() can take linear time but empty() is guaranteed to take constant time.

Issue(s) found via [cppcheck](http://cppcheck.sourceforge.net/).
