### PR TITLE
Use nan to make it compatible with node 0.11.x

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,70 +1,70 @@
 {
-	"targets": [
-		{
-			'target_name': 'msgpackBinding',
-			'sources': [
-				'src/msgpack.cc',
-			],
-			'include_dirs': [
-				'deps/msgpack'
-			],
-			'dependencies': [
-				'deps/msgpack/msgpack.gyp:libmsgpack'
-			],
-			'cflags_cc': [
-					'-Wall',
-					'-O3'
-				],
-				'cflags': [
-					'-Wall',
-					'-O3'
-				],
-				'cflags!': [
-          '-fno-exceptions',
-          '-Wno-unused-function'
-        ],
-				'cflags_cc!': [
-          '-fno-exceptions',
-          '-Wno-unused-function'
-        ],
-				'conditions': [
-					['OS=="mac"', {
-						'configurations': {
-							'Debug': {
-						    'xcode_settings': {
-						    	'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-                  'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
-						    }
-              },
-							'Release': {
-						    'xcode_settings': {
-						    	'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-                  'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
-						    },
-              },
-            },
-					}],
-					['OS=="win"', {
-						'configurations': {
-							'Debug': {
-								'msvs_settings': {
-									'VCCLCompilerTool': {
-										'CompileAs': '2',
-										'ExceptionHandling': '1',
-									},
-								},
-							},
-							'Release': {
-								'msvs_settings': {
-									'VCCLCompilerTool': {
-										'CompileAs': '2',
-										'ExceptionHandling': '1',
-									},
-								},
-							},
-						},
-					}]
-				]
-			},
-	]
+    "targets": [
+        {
+            'target_name': 'msgpackBinding',
+            'sources': [
+                'src/msgpack.cc',
+            ],
+            'include_dirs': [
+                'deps/msgpack'
+            ],
+            'dependencies': [
+                'deps/msgpack/msgpack.gyp:libmsgpack'
+            ],
+            'cflags_cc': [
+                    '-Wall',
+                    '-O3'
+                ],
+                'cflags': [
+                    '-Wall',
+                    '-O3'
+                ],
+            'cflags!': [
+              '-fno-exceptions',
+              '-Wno-unused-function'
+            ],
+            'cflags_cc!': [
+              '-fno-exceptions',
+              '-Wno-unused-function'
+            ],
+            'conditions': [
+                ['OS=="mac"', {
+                    'configurations': {
+                        'Debug': {
+                            'xcode_settings': {
+                                'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                                'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
+                            }
+                        },
+                        'Release': {
+                            'xcode_settings': {
+                                'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+                                'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
+                            },
+                        },
+                    },
+                }],
+                ['OS=="win"', {
+                    'configurations': {
+                        'Debug': {
+                            'msvs_settings': {
+                                'VCCLCompilerTool': {
+                                    'CompileAs': '2',
+                                    'ExceptionHandling': '1',
+                                },
+                            },
+                        },
+                        'Release': {
+                            'msvs_settings': {
+                                'VCCLCompilerTool': {
+                                    'CompileAs': '2',
+                                    'ExceptionHandling': '1',
+                                },
+                            },
+                        },
+                    },
+                }]
+            ]
+        },
+    ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,8 @@
                 'src/msgpack.cc',
             ],
             'include_dirs': [
-                'deps/msgpack'
+                'deps/msgpack',
+               '<!(node -e "require(\'nan\')")'
             ],
             'dependencies': [
                 'deps/msgpack/msgpack.gyp:libmsgpack'

--- a/package.json
+++ b/package.json
@@ -64,9 +64,12 @@
 	"directories": {
 		"lib": "lib"
 	},
-  "devDependencies": {
-    "nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"
-  },
+	"dependencies" : {
+		"nan" : "~1.0.0"
+	},
+	"devDependencies": {
+		"nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"
+	},
 	"engines": {
 		"node": ">=0.8.x"
 	},

--- a/src/msgpack.cc
+++ b/src/msgpack.cc
@@ -282,26 +282,11 @@ static NAN_METHOD(pack) {
         }
     }
 
-    v8::Local<Object> slowBuffer = NanNewBufferHandle(
+    Local<Object> slowBuffer = NanNewBufferHandle(
         sb->data, sb->size, _free_sbuf, (void *)sb
     );
 
-    // godsflaw: this part makes msgpack.pack() 1x slower than JSON.stringify()
-    // reaching back into JS appears to be expensive.
-    v8::Local<Object> global = NanGetCurrentContext()->Global();
-    v8::Local<Value> bv = global->Get(NanNew<String>("Buffer"));
-
-    assert(bv->IsFunction());
-
-    Local<Function> bc = v8::Local<Function>::Cast(bv);
-    Handle<Value> cArgs[3] = {
-        slowBuffer,
-        NanNew<Integer>(sb->size),
-        NanNew<Integer>(0)
-    };
-    v8::Local<Object> fastBuffer = bc->NewInstance(3, cArgs);
-
-    NanReturnValue(fastBuffer);
+    NanReturnValue(slowBuffer);
 }
 
 // var o = msgpack.unpack(buf);


### PR DESCRIPTION
with the new v8 version in node 0.11.x almost everything is broken, nan package allows backward/forward compatibility for node 0.8.x, 0.10.x and 0.11.x

this patch also removes usage of "fast buffers", on node 0.11.x performance is just terrible and on 0.10.x there is almost no difference

node 0.10.28 "fast buffer":

```
msgpack.pack: 2607ms, JSON.stringify: 3998ms
ratio of msgpack.pack/JSON.stringify: 0.6520760380190095
✔ benchmark - msgpack.pack faster than JSON.stringify with array of 1m objects

msgpack.pack: 8969ms, JSON.stringify: 1281ms
ratio of msgpack.pack/JSON.stringify: 7.001561280249804
✖ benchmark - JSON.stringify faster than msgpack.pack over 1m calls

msgpack.unpack: 2917ms, JSON.parse: 793ms
ratio of JSON.parse/msgpack.unpack: 3.67843631778058
✔ benchmark - JSON.parse faster than msgpack.unpack over 1m calls

msgpack pack:   2541 ms
msgpack unpack: 13620 ms
json    pack:   4278 ms
json    unpack: 2647 ms

msgpack pack:   4478 ms
msgpack unpack: 13163 ms
json    pack:   4336 ms
json    unpack: 2777 ms

msgpack pack:   4007 ms
msgpack unpack: 13886 ms
json    pack:   3993 ms
json    unpack: 2651 ms

✔ benchmark - output above is from three runs on a 1m element array of objects

msgpack pack:   8815 ms
msgpack unpack: 3032 ms
json    pack:   1669 ms
json    unpack: 830 ms

msgpack pack:   8920 ms
msgpack unpack: 3029 ms
json    pack:   1659 ms
json    unpack: 828 ms

msgpack pack:   8899 ms
msgpack unpack: 3035 ms
json    pack:   1660 ms
json    unpack: 824 ms

✔ benchmark - output above is from three runs of 1m individual calls

FAILURES: 1/5 assertions failed (150454ms)
```

node 0.10.28 "slow buffers":

```
msgpack.pack: 2708ms, JSON.stringify: 4006ms
ratio of msgpack.pack/JSON.stringify: 0.6759860209685472
✔ benchmark - msgpack.pack faster than JSON.stringify with array of 1m objects

msgpack.pack: 7081ms, JSON.stringify: 1289ms
ratio of msgpack.pack/JSON.stringify: 5.493405740884406
✔ benchmark - JSON.stringify faster than msgpack.pack over 1m calls

msgpack.unpack: 2776ms, JSON.parse: 762ms
ratio of JSON.parse/msgpack.unpack: 3.643044619422572
✔ benchmark - JSON.parse faster than msgpack.unpack over 1m calls

msgpack pack:   2651 ms
msgpack unpack: 14222 ms
json    pack:   3920 ms
json    unpack: 2647 ms

msgpack pack:   4942 ms
msgpack unpack: 13231 ms
json    pack:   4249 ms
json    unpack: 2654 ms

msgpack pack:   4966 ms
msgpack unpack: 13422 ms
json    pack:   4177 ms
json    unpack: 2656 ms

✔ benchmark - output above is from three runs on a 1m element array of objects

msgpack pack:   6850 ms
msgpack unpack: 2974 ms
json    pack:   1569 ms
json    unpack: 806 ms

msgpack pack:   6908 ms
msgpack unpack: 2965 ms
json    pack:   1575 ms
json    unpack: 809 ms

msgpack pack:   6935 ms
msgpack unpack: 2913 ms
json    pack:   1577 ms
json    unpack: 812 ms

✔ benchmark - output above is from three runs of 1m individual calls

OK: 5 assertions (141239ms)
```

node 0.11.13 "fast buffers" :

```
msgpack.pack: 5014ms, JSON.stringify: 1360ms
ratio of msgpack.pack/JSON.stringify: 3.6867647058823527
✖ benchmark - msgpack.pack faster than JSON.stringify with array of 1m objects

msgpack.pack: 18353ms, JSON.stringify: 1536ms
ratio of msgpack.pack/JSON.stringify: 11.948567708333334
✖ benchmark - JSON.stringify faster than msgpack.pack over 1m calls

msgpack.unpack: 2741ms, JSON.parse: 1124ms
ratio of JSON.parse/msgpack.unpack: 2.438612099644128
✔ benchmark - JSON.parse faster than msgpack.unpack over 1m calls

msgpack pack:   2822 ms
msgpack unpack: 3839 ms
json    pack:   1066 ms
json    unpack: 2377 ms

msgpack pack:   5579 ms
msgpack unpack: 9951 ms
json    pack:   2061 ms
json    unpack: 2448 ms

msgpack pack:   5511 ms
msgpack unpack: 10170 ms
json    pack:   2080 ms
json    unpack: 2434 ms

✔ benchmark - output above is from three runs on a 1m element array of objects

msgpack pack:   18859 ms
msgpack unpack: 3290 ms
json    pack:   1461 ms
json    unpack: 1192 ms

msgpack pack:   18108 ms
msgpack unpack: 2807 ms
json    pack:   1488 ms
json    unpack: 1211 ms

msgpack pack:   18677 ms
msgpack unpack: 2756 ms
json    pack:   1412 ms
json    unpack: 1099 ms

✔ benchmark - output above is from three runs of 1m individual calls

FAILURES: 2/5 assertions failed (177405ms)
```

0.11.13 "slow buffer" :

```
msgpack.pack: 4514ms, JSON.stringify: 1331ms
ratio of msgpack.pack/JSON.stringify: 3.391435011269722
✖ benchmark - msgpack.pack faster than JSON.stringify with array of 1m objects


msgpack.pack: 7534ms, JSON.stringify: 1507ms
ratio of msgpack.pack/JSON.stringify: 4.999336429993364
✔ benchmark - JSON.stringify faster than msgpack.pack over 1m calls

msgpack.unpack: 2826ms, JSON.parse: 1121ms
ratio of JSON.parse/msgpack.unpack: 2.5209634255129347
✔ benchmark - JSON.parse faster than msgpack.unpack over 1m calls

msgpack pack:   2757 ms
msgpack unpack: 4060 ms
json    pack:   1074 ms
json    unpack: 2347 ms

msgpack pack:   5835 ms
msgpack unpack: 9729 ms
json    pack:   2025 ms
json    unpack: 2494 ms

msgpack pack:   5469 ms
msgpack unpack: 9691 ms
json    pack:   2094 ms
json    unpack: 2502 ms

✔ benchmark - output above is from three runs on a 1m element array of objects

msgpack pack:   7985 ms
msgpack unpack: 3183 ms
json    pack:   1500 ms
json    unpack: 1207 ms

msgpack pack:   7278 ms
msgpack unpack: 2788 ms
json    pack:   1476 ms
json    unpack: 1203 ms

msgpack pack:   7524 ms
msgpack unpack: 3048 ms
json    pack:   1468 ms
json    unpack: 1145 ms

✔ benchmark - output above is from three runs of 1m individual calls

FAILURES: 1/5 assertions failed (122555ms)
```
