### PR TITLE
Make project compatible with Node 0.11 and io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"lib": "lib"
 	},
 	"dependencies" : {
-		"nan" : "~1.0.0"
+		"nan" : "^1.5.1"
 	},
 	"devDependencies": {
 		"nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"


### PR DESCRIPTION
By updating nan to the latest version, the project will be compatible
with Node.JS 0.11.x and io.js 1.0.2.
