### PR TITLE
Enable travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+
+node_js:
+  - "0.8"
+  - "0.10"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+


### PR DESCRIPTION
This PR enables builds on travis for Node.JS 0.8 and 0.10. Once #21 is merged we can also enable builds for Node.JS 0.11 and might also add a build for io.js. Please not that you will have to https://travis-ci.org/profile/sdepold and enable the build for the project.
