### PR TITLE
update NAN (NAN 1.6.0 has a bug that can't be compiled under iojs but 1.6.2 fixed it)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"lib": "lib"
 	},
 	"dependencies" : {
-		"nan" : "^1.5.1"
+		"nan" : "^1.6.2"
 	},
 	"devDependencies": {
 		"nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"


### PR DESCRIPTION
A few days ago, NAN in msgpack-node ought to be the version of 1.6.0.

Bug 1.6.0 has a bug that failed compiling under iojs, so NAN used to be 1.5.\* in msgpack-node.

But now 1.6.1 fixed this bug via PR https://github.com/rvagg/nan/pull/273, so we can use NAN 1.6.2 now!
