### PR TITLE
Fix build for node v0.12.7

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,8 @@
             ],
             'cflags_cc': [
                     '-Wall',
-                    '-O3'
+                    '-O3',
+                    '-std=c++11',
                 ],
                 'cflags': [
                     '-Wall',

--- a/binding.gyp
+++ b/binding.gyp
@@ -36,12 +36,14 @@
                             'xcode_settings': {
                                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                                 'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
+                                'OTHER_CFLAGS': ['-std=c++11'],
                             }
                         },
                         'Release': {
                             'xcode_settings': {
                                 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
                                 'WARNING_CFLAGS': ['-Wall', '-Wno-unused-function'],
+                                'OTHER_CFLAGS': ['-std=c++11'],
                             },
                         },
                     },

--- a/src/msgpack.cc
+++ b/src/msgpack.cc
@@ -31,12 +31,12 @@ class MsgpackException {
             msg(Nan::New<String>(str).ToLocalChecked()) {
         }
 
-        Handle<Value> getThrownException() {
-            return Exception::TypeError(msg);
+        Local<Value> getThrownException() {
+            return Nan::TypeError(msg);
         }
 
     private:
-        const Handle<String> msg;
+        const Local<String> msg;
 };
 
 // A holder for a msgpack_zone object; ensures destruction on scope exit
@@ -190,7 +190,7 @@ v8_to_msgpack(Handle<Value> v8obj, msgpack_object *mo, msgpack_zone *mz, size_t 
 //
 // This method is recursive. It will probably blow out the stack on objects
 // with extremely deep nesting.
-static Handle<Value>
+static Local<Value>
 msgpack_to_v8(msgpack_object *mo) {
     switch (mo->type) {
     case MSGPACK_OBJECT_NIL:


### PR DESCRIPTION
This changes the minimal amount of code to get msgpack to build on node
0.12.7 (and still build on node 4.1.1).
- Make sure to build using C++11 (This is the default with node 4.1.1).
- Fixes few thing there and there to be Nan compliant.

The code could be cleaned up to be future proof with Nan, but this are the minimal changes to get going.

Fixes msgpack/msgpack-node#28
