### PR TITLE
Change the timing to emit 'msg' event to consume a buffer in advance

### DIFF
--- a/lib/msgpack.js
+++ b/lib/msgpack.js
@@ -74,7 +74,6 @@ var Stream = function(s) {
                 break;
             }
 
-            self.emit('msg', msg);
             if (unpack.bytes_remaining > 0) {
                 self.buf = self.buf.slice(
                     self.buf.length - unpack.bytes_remaining,
@@ -83,6 +82,7 @@ var Stream = function(s) {
             } else {
                 self.buf = null;
             }
+            self.emit('msg', msg);
         }
     });
 };


### PR DESCRIPTION
When I work with msgpack.Stream + deasync(https://github.com/abbr/deasync), the following program causes stack overflow.
This issue is caused because msgpack.Stream emits 'msg' event before it consumes a buffer and deasync allows processing io events before finishing 'msg' event callbacks.
I know this doesn't usually happen but it's better to emit 'msg' after consuming a buffer to handle this kind of case.

```
'use strict'

var net = require('net');
var path = '/tmp/deasync.sock';
var msgpack = require('msgpack');

var server = net.createServer(function(c) {
  c.on('data', function() {
    c.write(msgpack.pack('foo'));
  });
  c.on('end', function() {
    console.log('end')
    server.close()
  })
  c.write(msgpack.pack('hello'));
});
server.listen(path);

var done = false;
var client = net.createConnection(path)
var stream = new msgpack.Stream(client)
stream.on('msg', function(msg) {
  console.log('msg: ' + msg)
  if (msg === 'hello') {
    client.write(msgpack.pack('foo'));
    require('deasync').loopWhile(() => !done);
    console.log('done');
    client.end()
  } else if (msg === 'foo') {
    done = true;
  }
});
```

Output

```
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
msg: hello
:0



RangeError: Maximum call stack size exceeded
```
