### PR TITLE
Update dependency Nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"lib": "lib"
 	},
 	"dependencies" : {
-		"nan" : "^2.0.9"
+		"nan" : "2.3.x"
 	},
 	"devDependencies": {
 		"nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"


### PR DESCRIPTION
For Node 6, version 2.2.0 of Nan or higher is required.

```
In file included from ../src/msgpack.cc:9:
../../nan/nan.h:590:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback
      ~~~~~~~~~~~~~^
../../nan/nan.h:596:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback) {
      ~~~~~~~~~~~~~^
../../nan/nan.h:601:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback
      ~~~~~~~~~~~~~^
../../nan/nan.h:607:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback) {
      ~~~~~~~~~~~~~^
4 errors generated.
make: *** [Release/obj.target/msgpackBinding/src/msgpack.o] Error 1
```

This is resolved by Nan 2.2.0, see the [CHANGELOG.md](https://github.com/nodejs/nan/blob/master/CHANGELOG.md#220-jan-9-2016)

With NPM 2 and Nan dep version string set to ^2.0.9, a fresh install of msgpack will get Nan 2.3.3. This seems to work fine and I've run the unit tests on node 4.4.2 and 6.2.0. But with NPM 3 and peer deps, another package could anchor the version lower than 2.2.0. For example, one of my other deps has a dep on Nan ~2.0.8. I'm getting a shared version of 2.0.9, which meets both requirements. This NPM 3 world looks a bit scary and will definitely change how we craft our dep version strings.

After studying the Nan changelog, I noticed minor versions not only add but deprecate and remove features. Seems like it might be best to get away from the caret versioning as you may get an incompatible minor when Nan updates. That's how I landed on version string 2.3.x. Another option would be ~2.3.3.

Thank you for creating this package and considering my request.
